### PR TITLE
Canonicalize CRAN links

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -82,7 +82,7 @@ valuesets(country="UK")
 
 ## Shiny web interface
 
-The calulation of multiple EQ-5D indices can also be performed by upload of a CSV or Excel file using the packaged [Shiny](https://shiny.rstudio.com) app. This requires the [shiny](https://cran.r-project.org/web/packages/shiny/index.html), [DT](https://cran.r-project.org/web/packages/DT/index.html), [mime](https://cran.r-project.org/web/packages/mime/index.html) and [readxl](https://cran.r-project.org/web/packages/readxl/index.html) packages. The CSV/Excel headers should be the same as the names of the vector passed to the **_eq5d_** function i.e. MO, SC, UA, PD and AD.  The app is launched using the **_shiny_eq5d_** function.
+The calulation of multiple EQ-5D indices can also be performed by upload of a CSV or Excel file using the packaged [Shiny](https://shiny.rstudio.com) app. This requires the [shiny](https://cran.r-project.org/package=shiny), [DT](https://cran.r-project.org/package=DT), [mime](https://cran.r-project.org/package=mime) and [readxl](https://cran.r-project.org/package=readxl) packages. The CSV/Excel headers should be the same as the names of the vector passed to the **_eq5d_** function i.e. MO, SC, UA, PD and AD.  The app is launched using the **_shiny_eq5d_** function.
 
 ```{r shiny, echo=TRUE, eval=FALSE}
 shiny_eq5d()

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ valuesets(country="UK")
 Shiny web interface
 -------------------
 
-The calulation of multiple EQ-5D indices can also be performed by upload of a CSV or Excel file using the packaged [Shiny](https://shiny.rstudio.com) app. This requires the [shiny](https://cran.r-project.org/web/packages/shiny/index.html), [DT](https://cran.r-project.org/web/packages/DT/index.html), [mime](https://cran.r-project.org/web/packages/mime/index.html) and [readxl](https://cran.r-project.org/web/packages/readxl/index.html) packages. The CSV/Excel headers should be the same as the names of the vector passed to the ***eq5d*** function i.e. MO, SC, UA, PD and AD. The app is launched using the ***shiny\_eq5d*** function.
+The calulation of multiple EQ-5D indices can also be performed by upload of a CSV or Excel file using the packaged [Shiny](https://shiny.rstudio.com) app. This requires the [shiny](https://cran.r-project.org/package=shiny), [DT](https://cran.r-project.org/package=DT), [mime](https://cran.r-project.org/package=mime) and [readxl](https://cran.r-project.org/package=readxl) packages. The CSV/Excel headers should be the same as the names of the vector passed to the ***eq5d*** function i.e. MO, SC, UA, PD and AD. The app is launched using the ***shiny\_eq5d*** function.
 
 ``` r
 shiny_eq5d()

--- a/vignettes/eq5d.Rmd
+++ b/vignettes/eq5d.Rmd
@@ -71,7 +71,7 @@ valuesets(country="UK")
 
 ## Shiny web interface
 
-The calulation of multiple EQ-5D indices can also be performed using the packaged [Shiny](https://shiny.rstudio.com) app and requires [shiny](https://cran.r-project.org/web/packages/shiny/index.html), [DT](https://cran.r-project.org/web/packages/DT/index.html), [mime](https://cran.r-project.org/web/packages/mime/index.html) and [xlsx](https://cran.r-project.org/web/packages/xlsx/index.html) packages. The CSV/xlsx headers should be the same as the names of the vector passed to the **_eq5d_** function i.e. MO, SC, UA, PD and AD.
+The calulation of multiple EQ-5D indices can also be performed using the packaged [Shiny](https://shiny.rstudio.com) app and requires [shiny](https://cran.r-project.org/package=shiny), [DT](https://cran.r-project.org/package=DT), [mime](https://cran.r-project.org/package=mime) and [xlsx](https://cran.r-project.org/package=xlsx) packages. The CSV/xlsx headers should be the same as the names of the vector passed to the **_eq5d_** function i.e. MO, SC, UA, PD and AD.
 
 ```{r shiny, eval=FALSE}
 shiny_eq5d()


### PR DESCRIPTION
CRAN [asks people](https://cran.r-project.org/doc/manuals/R-exts.html#Specifying-URLs) to use this URL variant when linking to packages ;-) This PR results from a semi-automatic search-and-replace script and implements their suggestion.