### PR TITLE
Speed up eq5d5l, eq5d3l and eq5d3y (closes #13)

### DIFF
--- a/R/eq5d5l.R
+++ b/R/eq5d5l.R
@@ -25,9 +25,9 @@ eq5d5l <- function(scores, country="England") {
   if(is.null(country) || !country %in% colnames(survey))
     stop(paste("Country must be one of:", paste(colnames(survey), collapse=", ")))
 
-  survey <- survey[country]
+  survey <- setNames(survey[[country]], rownames(survey))
 
-  values <- c(survey["StartValue",],
+  values <- c(survey["StartValue"],
               .dimensionScores(scores, survey),
               .minOneGreaterThan1(scores,survey),
               .level4Or5(scores, survey),
@@ -41,43 +41,34 @@ eq5d5l <- function(scores, country="England") {
 .level4Or5 <- function(scores, survey) {
   if(any(scores %in% c(4,5))) {
     idx <- which(scores %in% c(4,5))
-    values <- survey[paste0(names(scores)[idx], "45"),]
-    names(values) <- paste0(names(scores)[idx], "45")
-
-    return(values)
+    survey[paste0(names(scores)[idx], "45")]
   }
 }
 
 .num45sq <- function(scores, survey) {
   if(any(scores %in% c(4,5))) {
     idx <- which(scores %in% c(4,5))
-    (length(idx) - 1)^2 * survey["Num45sq",]
+    (length(idx) - 1)^2 * survey["Num45sq"]
   }
 }
 
 .minOneGreaterThan1 <- function(scores, survey) {
   ##at least one mobility, care, activity, pain, anxiety > 1
-  if(sum(scores) > 5 && !is.na(survey["Intercept",])) {
-    value <- survey["Intercept",]
-    names(value) <- "Intercept"
-    return(value) ##At least one 2 or 3 (constant)
+  if(sum(scores) > 5 && !is.na(survey["Intercept"])) {
+    survey["Intercept"] ##At least one 2 or 3 (constant)
   }
 }
 
 .N4 <- function(scores, survey) {
   ##at least one mobility, care, activity, pain, anxiety >= 4
-  if(any(scores >= 4) && !is.na(survey["N4",])) {
-    value <- survey["N4",]
-    names(value) <- "N4"
-    return(value)
+  if(any(scores >= 4) && !is.na(survey["N4"])) {
+    survey["N4"]
   }
 }
 
 .N5 <- function(scores, survey) {
   ##at least one mobility, care, activity, pain, anxiety == 5
-  if(any(scores == 5) && !is.na(survey["N5",])) {
-    value <- survey["N5",]
-    names(value) <- "N5"
-    return(value)
+  if(any(scores == 5) && !is.na(survey["N5"])) {
+    survey["N5"]
   }
 }

--- a/R/eq5dy.R
+++ b/R/eq5dy.R
@@ -29,9 +29,9 @@ eq5dy <- function(scores, country=NULL) {
   if(is.null(country) || !country %in% colnames(survey))
     stop(paste("Country must be one of:", paste(colnames(survey), collapse=", ")))
 
-  survey <- survey[country]
+  survey <- setNames(survey[[country]], rownames(survey))
 
-  values <- c(survey["FullHealth",],
+  values <- c(survey["FullHealth"],
               .intercept(scores, survey), .dimensionScores(scores, survey))
 
   return(round(sum(values, na.rm = TRUE), digits=3))
@@ -39,9 +39,7 @@ eq5dy <- function(scores, country=NULL) {
 
 .intercept <- function(scores, survey) {
   ##at least one mobility, care, activity, pain, anxiety > 1
-  if(sum(scores) > 5 && !is.na(survey["Intercept",])) {
-    value <- survey["Intercept",]
-    names(value) <- "Intercept"
-    return(value) ##At least one 2 or 3 (constant)
+  if(sum(scores) > 5 && !is.na(survey["Intercept"])) {
+    survey["Intercept"] ##At least one 2 or 3 (constant)
   }
 }

--- a/man/eq5d-package.Rd
+++ b/man/eq5d-package.Rd
@@ -6,7 +6,31 @@
 \alias{_PACKAGE}
 \title{eq5d: Methods for Analysing 'EQ-5D' Data and Calculating 'EQ-5D' Index Scores}
 \description{
-EQ-5D is a popular health related quality of life instrument used in the clinical and economic evaluation of health care. Developed by the EuroQol group <https://euroqol.org/>, the instrument consists of two components: health state description and evaluation. For the description component a subject self-rates their health in terms of five dimensions; mobility, self-care, usual activities, pain/discomfort, and anxiety/depression using either a three-level (EQ-5D-3L, <https://euroqol.org/eq-5d-instruments/eq-5d-3l-about/>) or a five-level (EQ-5D-5L, <https://euroqol.org/eq-5d-instruments/eq-5d-5l-about/>) scale. Frequently the scores on these five dimensions are converted to a single utility index using country specific value sets, which can be used in the clinical and economic evaluation of health care as well as in population health surveys. The eq5d package provides methods to calculate index scores from a subject's dimension scores. 29 TTO and 11 VAS EQ-5D-3L value sets including those for countries in Szende et al (2007) <doi:10.1007/1-4020-5511-0> and Szende et al (2014) <doi:10.1007/978-94-007-7596-1>, 29 EQ-5D-5L EQ-VT value sets from the EuroQol website, the EQ-5D-5L crosswalk value sets developed by van Hout et al. (2012) <doi:10.1016/j.jval.2012.02.008>, the crosswalk value set for Russia and reverse crosswalk value sets. Two EQ-5D-Y value sets are also included. Methods are also included for the analysis of EQ-5D profiles along with a shiny web tool to enable the calculation, visualisation and automated statistical analysis of EQ-5D data via a web browser using EQ-5D dimension scores stored in CSV or Excel files.
+EQ-5D is a popular health related quality of life instrument used 
+    in the clinical and economic evaluation of health care. Developed by the 
+    EuroQol group <https://euroqol.org/>, the instrument consists of two 
+    components: health state description and evaluation. For the description 
+    component a subject self-rates their health in terms of five dimensions; 
+    mobility, self-care, usual activities, pain/discomfort, and 
+    anxiety/depression using either a three-level (EQ-5D-3L,
+    <https://euroqol.org/eq-5d-instruments/eq-5d-3l-about/>) or a five-level
+    (EQ-5D-5L, <https://euroqol.org/eq-5d-instruments/eq-5d-5l-about/>) 
+    scale. Frequently the scores on these five dimensions are converted to a 
+    single utility index using country specific value sets, which can be used
+    in the clinical and economic evaluation of health care as well as in 
+    population health surveys. The eq5d package provides methods to calculate 
+    index scores from a subject's dimension scores. 29 TTO and 11 VAS EQ-5D-3L
+    value sets including those for countries in Szende et al (2007) 
+    <doi:10.1007/1-4020-5511-0> and Szende et al (2014) 
+    <doi:10.1007/978-94-007-7596-1>, 29 EQ-5D-5L EQ-VT value sets from the 
+    EuroQol website, the EQ-5D-5L crosswalk value sets developed by 
+    van Hout et al. (2012) <doi:10.1016/j.jval.2012.02.008>, the
+    crosswalk value set for Russia and reverse crosswalk value sets. Two 
+    EQ-5D-Y value sets are also included. Methods are also included for the 
+    analysis of EQ-5D profiles along with a shiny web tool to enable the 
+    calculation, visualisation and automated statistical analysis of EQ-5D 
+    data via a web browser using EQ-5D dimension scores stored in CSV or 
+    Excel files.
 }
 \seealso{
 Useful links:

--- a/man/eq5d3l.Rd
+++ b/man/eq5d3l.Rd
@@ -18,7 +18,7 @@ Mobility, Self-care, Usual activities, Pain/discomfort and Anxiety/depression.}
 calculated utility index score.
 }
 \description{
-Calculate indices for EQ-5D-3L value sets. Available value sets can be viewed 
+Calculate indices for EQ-5D-3L value sets. Available value sets can be viewed
   using the function \code{valuesets}.
 }
 \examples{


### PR DESCRIPTION
This commit relates to https://github.com/fragla/eq5d/issues/13.
Rather than extract values from a single column data frame using
rownames we can extract from a named vector using almost identical
syntax. This avoids the overhead of `[.data.frame` which does add
up when calling `eq5d()` across larger datasets and/or when applying
across multiple countries.